### PR TITLE
remove pywin32 to allow free-threading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ requires-python = ">=3.8"
 dependencies = [
   "platformdirs>=2.5",
   "traitlets>=5.3",
-  "pywin32>=300 ; sys_platform == 'win32' and platform_python_implementation != 'PyPy'"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
it's already ok for pypy, so why not